### PR TITLE
Add replacement rule for gazebo11 (classic) to allow overwriting of gz CLI executable

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -22,8 +22,10 @@ Pre-Depends: ${misc:Pre-Depends}
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
          ${misc:Depends}
-Breaks: ignition-tools
-Replaces: ignition-tools
+Breaks: ignition-tools,
+        gazebo11
+Replaces: ignition-tools,
+          gazebo11
 Multi-Arch: same
 Description: Entry point for using all the suite of ignition tools - app
  Ignition tools provide the ign command line tool that accepts multiple


### PR DESCRIPTION
Part of: https://github.com/gazebo-tooling/release-tools/issues/698

This install rule targets [`gazebo.install` file for `gazebo11`](https://github.com/gazebo-release/gazebo11-release/blob/main/ubuntu/debian/gazebo.install), which installs the `gz` executable. Using the [overwriting rules](https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces).

I am unsure if we should have a corresponding line on [`gazebo11-release`](https://github.com/gazebo-release/gazebo11-release) to allow Gazebo Classic to be installed on top of the pre-existing (garden) `gz` executable (overwriting the `gz` executable then.)