### PR TITLE
Don't install ign bash completion

### DIFF
--- a/ubuntu/debian/ignition-tools.install
+++ b/ubuntu/debian/ignition-tools.install
@@ -1,5 +1,4 @@
 #!/usr/bin/dh-exec
 usr/bin/*
 usr/lib/*/libignition-tools[0-99]-backward.so
-etc/ign.bash_completion.sh => /usr/share/bash-completion/completions/ign
 etc/gz.bash_completion.sh => /usr/share/bash-completion/completions/gz


### PR DESCRIPTION
* Follow up to #5 
* Part of https://github.com/gazebo-tooling/release-tools/issues/739 

I pulled the trigger too quickly, we need to remove this file.

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools2-debbuilder&build=175)](https://build.osrfoundation.org/job/ign-tools2-debbuilder/175/)