### PR TITLE
Declare Conflicts for gazebo11/gazebo pkgs

### DIFF
--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,3 +1,9 @@
+gz-tools2 (2.0.0~pre2-1~focal) focal; urgency=medium
+
+  * gz-tools2 2.0.0~pre2-1 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Fri, 16 Sep 2022 19:13:17 +0200
+
 gz-tools2 (2.0.0~pre1-2~focal) focal; urgency=medium
 
   * gz-tools2 2.0.0~pre1-2 release

--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,3 +1,9 @@
+gz-tools2 (2.0.0~pre2-1~jammy) jammy; urgency=medium
+
+  * gz-tools2 2.0.0~pre2-1 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Fri, 16 Sep 2022 19:13:16 +0200
+
 gz-tools2 (2.0.0~pre1-2~jammy) jammy; urgency=medium
 
   * gz-tools2 2.0.0~pre1-2 release

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -22,10 +22,10 @@ Pre-Depends: ${misc:Pre-Depends}
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby | ruby-interpreter,
          ${misc:Depends}
-Breaks: gazebo11,
-        ignition-tools2 (<< 1.999.999+nightly+git20220630+1r4051562399e3f34a3b41f601839247f071f80319-1)
-Replaces: gazebo11,
-          ignition-tools2 (<< 1.999.999+nightly+git20220630+1r4051562399e3f34a3b41f601839247f071f80319-1)
+Conflicts: gazebo (>= 11.0.0),
+           gazebo11
+Breaks: ignition-tools2 (<< 1.999.999+nightly+git20220630+1r4051562399e3f34a3b41f601839247f071f80319-1)
+Replaces: ignition-tools2 (<< 1.999.999+nightly+git20220630+1r4051562399e3f34a3b41f601839247f071f80319-1)
 Multi-Arch: same
 Description: Entry point for using all the suite of Gazebo tools - app
  Gazebo tools provide the gz command line tool that accepts multiple


### PR DESCRIPTION
Instead of using Break + Replaces, move the conflict on this package to `Conflicts` since both packages (gz-tools2 and gazebo11) plan to ship the same executable `gz`.  Should help to deal with https://github.com/gazebo-tooling/release-tools/issues/825 and https://github.com/gazebo-tooling/release-tools/issues/823. 