### PR TITLE
gz-tools.install: install libs with soversion

### DIFF
--- a/ubuntu/debian/gz-tools.install
+++ b/ubuntu/debian/gz-tools.install
@@ -1,3 +1,3 @@
 usr/bin/*
-usr/lib/*/lib*-tools[0-99]-backward.so
+usr/lib/*/lib*-tools[0-99]-backward.so*
 usr/share/*


### PR DESCRIPTION
Follow-up to gazebosim/gz-tools#133, as debbuilds have been unstable ([![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-tools2-debbuilder&build=1388)](https://build.osrfoundation.org/job/gz-tools2-debbuilder/1388/)) since that PR, and downstream libraries are unable to find `libgz-tools2-backward.so.2.0` (see https://github.com/gazebosim/gz-transport/pull/479#discussion_r1482203535).

## Testing with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-tools2-debbuilder&build=1389)](https://build.osrfoundation.org/job/gz-tools2-debbuilder/1389/) https://build.osrfoundation.org/job/gz-tools2-debbuilder/1389/